### PR TITLE
try to fix that minions would stuck behind the tower

### DIFF
--- a/minion.cpp
+++ b/minion.cpp
@@ -115,11 +115,19 @@ void Minion::walk()
     int target_x, target_y;
     int random_effect[3] = {-1, 0, 1};
     int ran = random_effect[qrand() % 3];
-
+    
     /* decide walking target */
     if(group == 1) { /* left side */
-        if(fixed_x <= 10) {
-            if(y < 25) { /* upper bridge */
+        if(fixed_x <= 10) {/* upper bridge */
+            if(fixed_y < 6 && (fixed_x == 3 || fixed_y == 4) && battle->map[5][7] == '#'){/*fix stuck tower*/
+                target_x = 1;
+                target_y = 5;
+            }
+            else if(fixed_y < 6 && (fixed_x == 5 || fixed_y == 6) && battle->map[5][7] == '#' ){
+                target_x = 7;
+                target_y = 5;
+            }
+            else(y < 25) { /* upper bridge */
                 target_x = 6 + ran;
                 target_y = 25;
             }
@@ -132,8 +140,16 @@ void Minion::walk()
                 target_y = 45;
             }
         }
-        else {
-            if(y < 25) { /* lower bridge */
+        else {/* lower bridge */
+            if(fixed_y < 6 && (fixed_x == 17 || fixed_y == 18 ) && battle->map[16][7] == '#'){/*fix stuck tower*/
+                target_x = 20;
+                target_y = 5;
+            }
+            else if(fixed_y < 6 && (fixed_x == 15 || fixed_y == 16 ) && battle->map[16][7] == '#'){
+                target_x = 14;
+                target_y = 5;
+            }
+            else if(y < 25) { /* lower bridge */
                 target_x = 15 + ran;
                 target_y = 25;
             }
@@ -148,8 +164,16 @@ void Minion::walk()
         }
     }
     else { /* group2 */
-        if(fixed_x <= 10) {
-            if(y > 26) { /* upper bridge */
+        if(fixed_x <= 10) { /* upper bridge */
+            if(fixed_y > 45 && (fixed_x == 3 || fixed_y == 4 ) && battle->map[5][44] == '#'){/*fix stuck tower*/
+                target_x = 1;
+                target_y = 46;
+            }
+            else if(fixed_y >45 && (fixed_x == 5 || fixed_y == 6 ) && battle->map[5][44] == '#'){
+                target_x = 7;
+                target_y = 46;
+            }
+            else if(y > 26) {
                 target_x = 6 + ran;
                 target_y = 26;
             }
@@ -163,7 +187,15 @@ void Minion::walk()
             }
         }
         else {
-            if(y > 26) { /* lower bridge */
+            if(fixed_y > 45 && (fixed_x == 17 || fixed_y == 18 ) && battle->map[16][44] == '#'){/*fix stuck tower*/
+                target_x = 20;
+                target_y = 46;
+            }
+            else if(fixed_y > 45 && (fixed_x == 15 || fixed_y == 16 ) && battle->map[16][44] == '#'){
+                target_x = 14;
+                target_y = 46;
+            }
+            else if(y > 26) { /* lower bridge */
                 target_x = 15 + ran;
                 target_y = 26;
             }
@@ -177,21 +209,21 @@ void Minion::walk()
             }
         }
     }
-
+    
     float base = qFabs(target_x - x) + qFabs(target_y - y);
-
+    
     int temp_x = static_cast<int>(x);
     int temp_y = static_cast<int>(y);
-
+    
     float dir_x = (target_x - x) * walkSpeed / base;
     float dir_y = (target_y - y) * walkSpeed / base;
-
+    
     if(fixed_x == temp_x) x += dir_x;
     if(fixed_y == temp_y) y += dir_y;
-
+    
     battle->map[fixed_x][fixed_y] = ' ';
     battle->map_hp[fixed_x][fixed_y] = ' ';
-
+    
     if(fixed_x != static_cast<int>(x)) {
         if(battle->map[temp_x][fixed_y] == ' ') {
             fixed_x = temp_x;
@@ -202,10 +234,11 @@ void Minion::walk()
             fixed_y = temp_y;
         }
     }
-
+    
     battle->map[fixed_x][fixed_y] = minion_num;
     setWalkDirection(target_x, target_y);
 }
+
 
 void Minion::setWalkDirection(float target_x, float target_y)
 {

--- a/minion.cpp
+++ b/minion.cpp
@@ -127,7 +127,7 @@ void Minion::walk()
                 target_x = 7;
                 target_y = 5;
             }
-            else(y < 25) { /* upper bridge */
+            else if(y < 25) { /* upper bridge */
                 target_x = 6 + ran;
                 target_y = 25;
             }

--- a/minion.cpp
+++ b/minion.cpp
@@ -119,13 +119,9 @@ void Minion::walk()
     /* decide walking target */
     if(group == 1) { /* left side */
         if(fixed_x <= 10) {/* upper bridge */
-            if(fixed_y < 6 && (fixed_x == 3 || fixed_y == 4) && battle->map[5][7] == '#'){/*fix stuck tower*/
-                target_x = 1;
-                target_y = 5;
-            }
-            else if(fixed_y < 6 && (fixed_x == 5 || fixed_y == 6) && battle->map[5][7] == '#' ){
-                target_x = 7;
-                target_y = 5;
+            if( fixed_y < 10 && ( fixed_x <= 6) && battle->map[5][7] == '#'){/*fix stuck tower*/
+                target_x = 2 ;
+                target_y = 11 +ran;
             }
             else if(y < 25) { /* upper bridge */
                 target_x = 6 + ran;
@@ -141,15 +137,11 @@ void Minion::walk()
             }
         }
         else {/* lower bridge */
-            if(fixed_y < 6 && (fixed_x == 17 || fixed_y == 18 ) && battle->map[16][7] == '#'){/*fix stuck tower*/
-                target_x = 20;
-                target_y = 5;
+            if(fixed_y < 10 && fixed_x >=15 && battle->map[16][7] == '#'){/*fix stuck tower*/
+                target_x = 19;
+                target_y = 11+ran;
             }
-            else if(fixed_y < 6 && (fixed_x == 15 || fixed_y == 16 ) && battle->map[16][7] == '#'){
-                target_x = 14;
-                target_y = 5;
-            }
-            else if(y < 25) { /* lower bridge */
+           else if(y < 25) { /* lower bridge */
                 target_x = 15 + ran;
                 target_y = 25;
             }
@@ -165,15 +157,11 @@ void Minion::walk()
     }
     else { /* group2 */
         if(fixed_x <= 10) { /* upper bridge */
-            if(fixed_y > 45 && (fixed_x == 3 || fixed_y == 4 ) && battle->map[5][44] == '#'){/*fix stuck tower*/
-                target_x = 1;
-                target_y = 46;
+            if(fixed_y > 41 && fixed_x<=6 && battle->map[5][44] == '#'){/*fix stuck tower*/
+                target_x = 2;
+                target_y = 40 - ran;
             }
-            else if(fixed_y >45 && (fixed_x == 5 || fixed_y == 6 ) && battle->map[5][44] == '#'){
-                target_x = 7;
-                target_y = 46;
-            }
-            else if(y > 26) {
+           else if(y > 26) {
                 target_x = 6 + ran;
                 target_y = 26;
             }
@@ -187,15 +175,11 @@ void Minion::walk()
             }
         }
         else {
-            if(fixed_y > 45 && (fixed_x == 17 || fixed_y == 18 ) && battle->map[16][44] == '#'){/*fix stuck tower*/
-                target_x = 20;
-                target_y = 46;
+            if(fixed_y > 41 && fixed_x>=15 && battle->map[16][44] == '#'){/*fix stuck tower*/
+                target_x = 19;
+                target_y = 40 - ran;
             }
-            else if(fixed_y > 45 && (fixed_x == 15 || fixed_y == 16 ) && battle->map[16][44] == '#'){
-                target_x = 14;
-                target_y = 46;
-            }
-            else if(y > 26) { /* lower bridge */
+           else if(y > 26) { /* lower bridge */
                 target_x = 15 + ran;
                 target_y = 26;
             }


### PR DESCRIPTION
如果將minion放在塔正後方的位置
將target_x,target_y 先設為可以走出去的縫隙
以避免卡在牆後動彈不得的狀況